### PR TITLE
fixup! Record handler: allow force of create_date

### DIFF
--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -280,7 +280,7 @@ class ImportRecordset(models.Model, JobRelatedMixin):
     def generate_report(self):
         self.ensure_one()
         reporter = self.get_source().get_reporter()
-        if not reporter:
+        if reporter is None:
             logger.debug('No reporter found...')
             return
         metadata, content = reporter.report_get(self)

--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import json
+import base64
 import os
 from collections import OrderedDict
 
@@ -285,7 +286,7 @@ class ImportRecordset(models.Model, JobRelatedMixin):
             return
         metadata, content = reporter.report_get(self)
         self.write({
-            'report_file': content.encode('base64'),
+            'report_file': base64.encodestring(content.encode()),
             'report_filename': metadata['complete_filename']
         })
         logger.info((

--- a/connector_importer/models/reporter.py
+++ b/connector_importer/models/reporter.py
@@ -25,7 +25,7 @@ class ReporterMixin(models.AbstractModel):
     @api.model
     def report_get(self, recordset, **options):
         """Create and return a report for given recordset."""
-        fileout = io.BytesIO()
+        fileout = io.StringIO()
         self.report_do(recordset, fileout, **options)
         self.report_finalize(recordset, fileout, **options)
         metadata = self.report_get_metadata(recordset, **options)


### PR DESCRIPTION
`get_reporter()` always returns an empty recordset -> this check is broken

get will return `None` if it can't find the model, so we should check on that instead of falsy :)